### PR TITLE
Limit message length for sb and uwu to 200

### DIFF
--- a/src/commands/spongebob.ts
+++ b/src/commands/spongebob.ts
@@ -4,12 +4,19 @@ import { spongeCase } from 'sponge-case'
 
 @Discord()
 class Spongebob {
+  private mixuChannel = '930121577335496785'
+
   @SimpleCommand('sb', { description: 'Spongebobify text', argSplitter: '\n' })
-  simple(@SimpleCommandOption('text', { type: 'STRING' }) text: string | undefined, command: SimpleCommandMessage) {
+  async simple(@SimpleCommandOption('text', { type: 'STRING' }) text: string | undefined, command: SimpleCommandMessage) {
     if (!text) {
-      return command.sendUsageSyntax()
+      await command.message.reply({content: "Usage: >sb <text> (More than 200 characters only in the #mixu channel" , allowedMentions: { repliedUser: false }})
+      return
     }
-    command.message.reply(spongeCase(text))
+    if(text.length > 200 && command.message.channel.id !== this.mixuChannel) {
+      await command.message.reply({ content: 'Messages longer than 200 characters are only allowed in the #mixu channel.', allowedMentions: { repliedUser: false } })
+      return
+    }
+    await command.message.reply({content: spongeCase(text), allowedMentions: { repliedUser: false } } )
   }
 
   @Slash('sb', { description: 'Spongebobify text' })
@@ -18,6 +25,10 @@ class Spongebob {
     message: string,
     interaction: CommandInteraction
   ) {
-    interaction.reply(spongeCase(message))
+    if(message.length > 200 && interaction.channel?.id !== this.mixuChannel) {
+      await interaction.reply({ content: 'Messages longer than 200 characters are only allowed in the #mixu channel.', ephemeral: true })
+      return
+    }
+    await interaction.reply(spongeCase(message))
   }
 }

--- a/src/commands/spongebob.ts
+++ b/src/commands/spongebob.ts
@@ -4,16 +4,16 @@ import { spongeCase } from 'sponge-case'
 
 @Discord()
 class Spongebob {
-  private mixuChannel = '930121577335496785'
+  private mainChannel = '103678524375699456'
 
   @SimpleCommand('sb', { description: 'Spongebobify text', argSplitter: '\n' })
   async simple(@SimpleCommandOption('text', { type: 'STRING' }) text: string | undefined, command: SimpleCommandMessage) {
     if (!text) {
-      await command.message.reply({content: "Usage: >sb <text> (More than 200 characters only in the #mixu channel" , allowedMentions: { repliedUser: false }})
+      await command.message.reply({content: "Usage: >sb <text> (More than 200 characters only outside of the main channel)" , allowedMentions: { repliedUser: false }})
       return
     }
-    if(text.length > 200 && command.message.channel.id !== this.mixuChannel) {
-      await command.message.reply({ content: 'Messages longer than 200 characters are only allowed in the #mixu channel.', allowedMentions: { repliedUser: false } })
+    if(text.length > 200 && command.message.channel.id === this.mainChannel) {
+      await command.message.reply({ content: 'Messages longer than 200 characters are only allowed outside of the main channel.', allowedMentions: { repliedUser: false } })
       return
     }
     await command.message.reply({content: spongeCase(text), allowedMentions: { repliedUser: false } } )
@@ -25,8 +25,8 @@ class Spongebob {
     message: string,
     interaction: CommandInteraction
   ) {
-    if(message.length > 200 && interaction.channel?.id !== this.mixuChannel) {
-      await interaction.reply({ content: 'Messages longer than 200 characters are only allowed in the #mixu channel.', ephemeral: true })
+    if(message.length > 200 && interaction.channel?.id === this.mainChannel) {
+      await interaction.reply({ content: 'Messages longer than 200 characters are only allowed outside of the main channel.', ephemeral: true })
       return
     }
     await interaction.reply(spongeCase(message))

--- a/src/commands/uwu.ts
+++ b/src/commands/uwu.ts
@@ -22,7 +22,7 @@ export const uwuify = (text: string): string => {
 
 @Discord()
 class UwU {
-  private mixuChannel = '930121577335496785'
+  private mainChannel = '103678524375699456'
 
   @SimpleCommand('uwu', { description: 'UwUify text', argSplitter: '\n' })
   async simple(
@@ -30,12 +30,12 @@ class UwU {
     command: SimpleCommandMessage
   ) {
     if (!text) {
-      await command.message.reply({content: "Usage: >uwu <text> (More than 200 characters only in the #mixu channel" , allowedMentions: { repliedUser: false }})
+      await command.message.reply({content: "Usage: >uwu <text> (More than 200 characters only outside of the main channel)" , allowedMentions: { repliedUser: false }})
       return
     }
 
-    if(text.length > 200 && command.message.channel.id !== this.mixuChannel) {
-      await command.message.reply({ content: 'Messages longer than 200 characters are only allowed in the #mixu channel.', allowedMentions: { repliedUser: false } })
+    if(text.length > 200 && command.message.channel.id === this.mainChannel) {
+      await command.message.reply({ content: 'Messages longer than 200 characters are only allowed outside of the main channel.', allowedMentions: { repliedUser: false } })
       return
     }
     await command.message.reply({content: uwuify(text), allowedMentions: { repliedUser: false } } )
@@ -47,7 +47,7 @@ class UwU {
     text: string,
     interaction: CommandInteraction
   ) {
-    if(text.length > 200 && interaction.channel?.id !== this.mixuChannel) {
+    if(text.length > 200 && interaction.channel?.id === this.mainChannel) {
       interaction.reply({ content: 'Messages longer than 200 characters are only allowed in the #mixu channel.', ephemeral: true })
       return
     }

--- a/src/commands/uwu.ts
+++ b/src/commands/uwu.ts
@@ -22,16 +22,23 @@ export const uwuify = (text: string): string => {
 
 @Discord()
 class UwU {
+  private mixuChannel = '930121577335496785'
+
   @SimpleCommand('uwu', { description: 'UwUify text', argSplitter: '\n' })
   async simple(
     @SimpleCommandOption('text', { type: 'STRING' }) text: string | undefined,
     command: SimpleCommandMessage
   ) {
     if (!text) {
-      return command.sendUsageSyntax()
+      await command.message.reply({content: "Usage: >uwu <text> (More than 200 characters only in the #mixu channel" , allowedMentions: { repliedUser: false }})
+      return
     }
 
-    await command.message.channel.send(uwuify(text))
+    if(text.length > 200 && command.message.channel.id !== this.mixuChannel) {
+      await command.message.reply({ content: 'Messages longer than 200 characters are only allowed in the #mixu channel.', allowedMentions: { repliedUser: false } })
+      return
+    }
+    await command.message.reply({content: uwuify(text), allowedMentions: { repliedUser: false } } )
   }
 
   @Slash('uwu', { description: 'UwUify text' })
@@ -40,8 +47,10 @@ class UwU {
     text: string,
     interaction: CommandInteraction
   ) {
-    await interaction.deferReply()
-
-    await interaction.followUp(uwuify(text))
+    if(text.length > 200 && interaction.channel?.id !== this.mixuChannel) {
+      interaction.reply({ content: 'Messages longer than 200 characters are only allowed in the #mixu channel.', ephemeral: true })
+      return
+    }
+    interaction.reply(uwuify(text))
   }
 }


### PR DESCRIPTION
Messages longer than 200 are only allowed in the #mixu channel. Also
replace the overly verbose usage text.
