### PR TITLE
Allow use of emotes to choose the icon

### DIFF
--- a/src/commands/roleCommands/icon.ts
+++ b/src/commands/roleCommands/icon.ts
@@ -168,12 +168,7 @@ class Icon {
   }
 
   private static parseEmoteName(emote: string): string {
-    if (emote.includes(':')) {
-      const emoteName = emote.match(RegExp(':(.+):'))
-      if (emoteName) {
-        return emoteName[1]
-      }
-    }
-    return emote
+    const emoteName = emote.match(RegExp(':(.+):'))
+    return emoteName ? emoteName[1] : emote
   }
 }

--- a/src/commands/roleCommands/icon.ts
+++ b/src/commands/roleCommands/icon.ts
@@ -5,7 +5,7 @@ import {
   SimpleCommandMessage,
   SimpleCommandOption,
   Slash,
-  SlashOption
+  SlashOption,
 } from 'discordx'
 import { CommandInteraction, GuildMemberRoleManager, RoleManager } from 'discord.js'
 import { SuperUsers } from '../../guards/RoleChecks'
@@ -167,12 +167,13 @@ class Icon {
     }
   }
 
-  private static parseEmoteName(emote: string): string | undefined {
-    const emoteName = emote.match(RegExp(':(.+):'))
-    if (emoteName) {
-      return emoteName[1]
-    } else {
-      return undefined
+  private static parseEmoteName(emote: string): string {
+    if (emote.includes(':')) {
+      const emoteName = emote.match(RegExp(':(.+):'))
+      if (emoteName) {
+        return emoteName[1]
+      }
     }
+    return emote
   }
 }

--- a/src/commands/roleCommands/icon.ts
+++ b/src/commands/roleCommands/icon.ts
@@ -147,7 +147,7 @@ class Icon {
       }
     }
 
-    const modifiedRoleName = `${emoteName} [ICON]`
+    const modifiedRoleName = `${Icon.parseEmoteName(emoteName)} [ICON]`
     const whichRole = guildRoles?.cache.find((role) => role.name.toLowerCase() === modifiedRoleName.toLowerCase())
     if (whichRole) {
       if (memberRoles?.cache.some((role) => role.id === whichRole.id)) {


### PR DESCRIPTION
Fix >icon and /icon commands not allowing the use of the actual emotes to choose the role.
Allow >createicon and >delicon to just use the name of the emotes instead of only the actual emotes.