### PR TITLE
Bug Fixes in RPG

### DIFF
--- a/src/commands/RPG/RPG.ts
+++ b/src/commands/RPG/RPG.ts
@@ -186,8 +186,8 @@ export class RPG {
         res.text =
           '▪ ' +
           res.text
-            .replace(/DEF/g, `**${defender.nickname}**[${defender.hp}]`)
-            .replace(/ATK/g, `**${attacker.nickname}**[${attacker.hp}]`)
+            .replace(/DEF/g, `**${defender.nickname ?? defender.user.username}**[${defender.hp}]`)
+            .replace(/ATK/g, `**${attacker.nickname ?? attacker.user.username}**[${attacker.hp}]`)
             .replace(/DMG/g, res.damage.toString())
 
         log += res.text + '\n'
@@ -232,8 +232,8 @@ export class RPG {
       textList = victoryTexts['STANDARD']
     }
     const summary: string = getRandomElement(textList)
-      .replace(/VICTOR/g, `**${victor.nickname}**`)
-      .replace(/LOSER/g, `**${loser.nickname}**`)
+      .replace(/VICTOR/g, `**${victor.nickname ?? victor.user.username}**`)
+      .replace(/LOSER/g, `**${loser.nickname ?? loser.user.username}**`)
     log += summary
 
     const result = {
@@ -421,7 +421,7 @@ export class RPG {
     if (challengerDBRecord.lastLoss.getTime() + RPG.cooldown > Date.now()) {
       await interaction.reply({
         content: `**${
-          challenger.nickname
+          challenger.nickname ?? challengerUser.user.username
         }**, you are still recovering from the last fight. Please wait ${getTimeLeftInReadableFormat(
           challengerDBRecord.lastLoss,
           RPG.cooldown
@@ -468,7 +468,9 @@ export class RPG {
         .setDisabled(true)
       const row = new MessageActionRow().addComponents(button)
       await interaction.editReply({
-        content: `No one was brave enough to do battle with **${challengerUser.nickname}**${challengerEloBand.icon}.`,
+        content: `No one was brave enough to do battle with **${
+          challengerUser.nickname ?? challengerUser.user.username
+        }**${challengerEloBand.icon}.`,
         components: [row],
       })
       this.challengeInProgress = false
@@ -482,7 +484,9 @@ export class RPG {
       .setLabel('Accept challenge')
     const row = new MessageActionRow().addComponents(button)
     const message = await interaction.reply({
-      content: `**${challenger.nickname}**${challengerEloBand.icon} is throwing down the gauntlet in challenge.`,
+      content: `**${challengerUser.nickname ?? challengerUser.user.username}**${
+        challengerEloBand.icon
+      } is throwing down the gauntlet in challenge.`,
       fetchReply: true,
       components: [row],
     })
@@ -581,7 +585,7 @@ export class RPG {
       if (accepterDBRecord.lastLoss.getTime() + RPG.cooldown > Date.now()) {
         await collectionInteraction.followUp({
           content: `**${
-            accepterUser.nickname
+            accepterUser.nickname ?? accepterUser.user.username
           }**, you have recently lost a fight. Please wait ${getTimeLeftInReadableFormat(
             accepterDBRecord.lastLoss,
             RPG.cooldown
@@ -688,10 +692,10 @@ export class RPG {
         await collectionInteraction.editReply({
           content:
             `${fightResult.summary}` +
-            `\n**${challenger.nickname}**${challengerEloBand.icon} ${challengerEloVerb} ${Math.abs(
-              challengerEloChange
-            )}LP [${challengerNewEloRank}]. ` +
-            `**${accepter.nickname}**${accepterEloBand.icon} ${accepterEloVerb} ${Math.abs(
+            `\n**${challenger.nickname ?? challenger.user.username}**${
+              challengerEloBand.icon
+            } ${challengerEloVerb} ${Math.abs(challengerEloChange)}LP [${challengerNewEloRank}]. ` +
+            `**${accepter.nickname ?? accepter.user.username}**${accepterEloBand.icon} ${accepterEloVerb} ${Math.abs(
               accepterEloChange
             )}LP [${accepterNewEloRank}]`,
         })

--- a/src/commands/RPG/RPG.ts
+++ b/src/commands/RPG/RPG.ts
@@ -11,7 +11,6 @@ import {
   MessageAttachment,
   MessageButton,
   MessageEmbed,
-  Options,
 } from 'discord.js'
 import { Discord, Slash, SlashGroup, SlashOption } from 'discordx'
 import { getCallerFromCommand } from '../../utils/CommandUtils'
@@ -723,6 +722,8 @@ export class RPG {
           data: {
             draws: { increment: 1 },
             eloRank: newEloRank,
+            peakElo: Math.max(stats.peakElo, newEloRank),
+            floorElo: Math.min(stats.floorElo, newEloRank),
           },
         })
         break
@@ -735,8 +736,8 @@ export class RPG {
           data: {
             wins: { increment: 1 },
             eloRank: newEloRank,
-            peakElo: Math.max(stats.eloRank, newEloRank),
-            floorElo: Math.min(stats.eloRank, newEloRank),
+            peakElo: Math.max(stats.peakElo, newEloRank),
+            floorElo: Math.min(stats.floorElo, newEloRank),
           },
         })
         break
@@ -749,8 +750,8 @@ export class RPG {
           data: {
             losses: { increment: 1 },
             eloRank: newEloRank,
-            peakElo: Math.max(stats.eloRank, newEloRank),
-            floorElo: Math.min(stats.eloRank, newEloRank),
+            peakElo: Math.max(stats.peakElo, newEloRank),
+            floorElo: Math.min(stats.floorElo, newEloRank),
             lastLoss: new Date(),
           },
         })

--- a/src/commands/RPG/RPG.ts
+++ b/src/commands/RPG/RPG.ts
@@ -264,6 +264,10 @@ export class RPG {
     const callingUser = callerMember?.user
     if (callingUser) {
       if (name) {
+        if (name.length >= 256) {
+          interaction.reply({ content: 'Name must be fewer than 256 characters', ephemeral: true })
+          return
+        }
         const character = new Character(callingUser, name, name)
         interaction.reply({ embeds: [character.toEmbed('')], ephemeral: silent })
       } else {
@@ -277,7 +281,7 @@ export class RPG {
         interaction.reply({ embeds: [character.toEmbed(eloBandIcon.icon)], ephemeral: silent })
       }
     } else {
-      interaction.reply({ content: 'Username undefined', ephemeral: silent })
+      interaction.reply({ content: 'Username undefined', ephemeral: true })
     }
   }
 
@@ -308,7 +312,10 @@ export class RPG {
         )
       await interaction.reply({ embeds: [statsEmbed], ephemeral: silent })
     } else {
-      await interaction.reply(`Hmm, ${interaction.user}... It seems you are yet to test your steel.`)
+      await interaction.reply({
+        content: `Hmm, ${interaction.user}... It seems you are yet to test your steel.`,
+        ephemeral: true,
+      })
     }
   }
 
@@ -367,7 +374,7 @@ export class RPG {
     if (results.top) {
       ladderEmbed.addField('Top', processPotentiallyPluralResults(results.top, 'TOP'))
     } else {
-      interaction.reply('The arena is clean. No violence has happened yet.')
+      interaction.reply({ content: 'The arena is clean. No violence has happened yet.', ephemeral: true })
       return
     }
     if (results.bottom) {


### PR DESCRIPTION
- Set max name length so `/rpg character` can't be used to crash bot
- Fixed so elo min/max is actually elo min/max
- Set backup to username on null nickname.