### PR TITLE
Dino Quality of Life update

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,6 +70,7 @@ model NFDItem {
   previousOwners  String    @default("")
   coveters        String    @default("")
   shunners        String    @default("")
+  enthusiasts     NFDEnthusiasts[]
   hotness         Int       @default(0)
 }
 
@@ -83,5 +84,18 @@ model NFDEnjoyer {
   consecutiveFails  Int       @default(4)
   successfulMints   Int       @default(0)
   failedMints       Int       @default(0)
-  favorites        String    @default("")
+  favorites         NFDEnthusiasts[]
+}
+
+// Opting to not use prisma's implicit many-to-many
+// I'm doing this so it's clear *what* is happening and also for future proofing should we wanat to add fields
+// to this relation
+model NFDEnthusiasts {
+  dino          NFDItem    @relation(fields: [dinoId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  dinoId        Int
+
+  enjoyer       NFDEnjoyer @relation(fields: [enjoyerId], references: [id], onUpdate: Cascade, onDelete: Cascade)
+  enjoyerId     String
+
+  @@id([dinoId, enjoyerId])
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,7 +60,8 @@ model RPGCharacter {
 }
 
 model NFDItem {
-  name            String    @id @unique
+  id              Int       @id @default(autoincrement())
+  name            String    @unique
   code            String    @unique
   filename        String    @unique
   owner           String
@@ -69,7 +70,7 @@ model NFDItem {
   previousOwners  String    @default("")
   coveters        String    @default("")
   shunners        String    @default("")
-  hotness         Int     @default(0)
+  hotness         Int       @default(0)
 }
 
 model NFDEnjoyer {
@@ -82,5 +83,5 @@ model NFDEnjoyer {
   consecutiveFails  Int       @default(4)
   successfulMints   Int       @default(0)
   failedMints       Int       @default(0)
-  favourite         String    @default("")
+  favorites        String    @default("")
 }

--- a/src/commands/NFD.ts
+++ b/src/commands/NFD.ts
@@ -705,9 +705,6 @@ class NFD {
         id: owner.id,
       },
       update: {},
-      include: {
-        favorites: true,
-      },
     })
 
     // Check for cooldowns.

--- a/src/commands/NFD.ts
+++ b/src/commands/NFD.ts
@@ -205,6 +205,11 @@ class NFD {
     owner: GuildMember,
     @SlashOption('silent', { type: ApplicationCommandOptionType.Boolean, required: false })
     silent = true,
+    @SlashOption('type', { type: ApplicationCommandOptionType.String, required: false })
+    @SlashChoice({ name: 'Favorites', value: 'FAVORITES' })
+    @SlashChoice({ name: 'Trash', value: 'TRASH' })
+    @SlashChoice({ name: 'All', value: 'ALL' })
+    type: 'ALL' | 'FAVORITES' | 'TRASH' = 'ALL',
     interaction: CommandInteraction
   ) {
     if (!interaction.guild) {
@@ -244,6 +249,32 @@ class NFD {
         content: `**${ownerName}** doesn't own any dinos. 🥚🙌`,
         ephemeral: silent,
       })
+    }
+
+    // Filter down the list to only include the requested type
+    const favorties = ownerRecord.favorites.split(',')
+    if (type == 'FAVORITES') {
+      collection = collection.filter((entry) => {
+        return favorties.includes(entry.id.toString())
+      })
+
+      if (collection.length == 0) {
+        return interaction.reply({
+          content: `All of **${ownerName}**'s dinos are trash. 🗑️`,
+          ephemeral: silent,
+        })
+      }
+    } else if (type == 'TRASH') {
+      collection = collection.filter((entry) => {
+        return !favorties.includes(entry.id.toString())
+      })
+
+      if (collection.length == 0) {
+        return interaction.reply({
+          content: `**${ownerName}** doesn't have any trash. All their dinos are perfect. 😌`,
+          ephemeral: silent,
+        })
+      }
     }
 
     collection = shuffleArray(collection)

--- a/src/commands/NFD.ts
+++ b/src/commands/NFD.ts
@@ -120,16 +120,6 @@ class NFD {
       })
     }
 
-    const parts = await this.makeNFDcode()
-
-    // Check to see if we failed to make a unique one
-    if (!parts) {
-      return interaction.reply({
-        content: "I tried really hard but I wasn't able to make a unique dino for you. Sorry... :'(",
-        ephemeral: true,
-      })
-    }
-
     // If we got this far then we are all set to hatch.
     // Roll the hatch check
     let res = roll_dy_x_TimesPick_z(4, 1, 1)
@@ -147,6 +137,16 @@ class NFD {
         content: `You failed to hatch the egg (${
           numbers[ownerRecordPrev.consecutiveFails]
         } attempt), better luck next time. You can try again <t:${nextMint}:R>`,
+      })
+    }
+
+    const parts = await this.makeNFDcode()
+
+    // Check to see if we failed to make a unique one
+    if (!parts) {
+      return interaction.reply({
+        content: "I tried really hard but I wasn't able to make a unique dino for you. Sorry... :'(",
+        ephemeral: true,
       })
     }
 

--- a/src/commands/NFD.ts
+++ b/src/commands/NFD.ts
@@ -52,8 +52,8 @@ type DinoStats = {
 // })
 @injectable()
 class NFD {
-  private MINT_COOLDOWN_METHOD: 'DAILY' | '23HOUR' = 'DAILY'
-  private MINT_COOLDOWN = 1000 //* 60 * 60 * 23
+  private MINT_COOLDOWN_METHOD: 'DAILY' | 'PERSONAL' = 'DAILY'
+  private MINT_COOLDOWN = 1000 * 60 * 60 * 23
   private MILISECONDS_IN_DAY = 86400000
   private GIFT_COOLDOWN = 1000 * 60 * 60
   private RENAME_COOLDOWN = 1000 * 60 * 60

--- a/src/commands/NFD.ts
+++ b/src/commands/NFD.ts
@@ -61,6 +61,7 @@ class NFD {
 
   private COVET_TIMEOUT = 1000 * 60 * 10
 
+  private MAXIMUM_FAILED_HATCHES = 3
   private MAXIMUM_MINT_ATTEMPTS = 10
 
   private MAXIMUM_ORGY_ATTENDEES = 50
@@ -153,7 +154,7 @@ class NFD {
       res = Math.max(res, roll_dy_x_TimesPick_z(4, 1, 1))
     }
 
-    if (res <= 3 - ownerRecordPrev.consecutiveFails) {
+    if (res <= this.MAXIMUM_FAILED_HATCHES - ownerRecordPrev.consecutiveFails) {
       this.updateDBfailedMint(ownerMember.id)
       const nextMint = Math.round((Date.now() + this.MINT_COOLDOWN) / 1000)
       const numbers = ['1st', '2nd', '3rd', '4th'] // Should never get to 4th


### PR DESCRIPTION
Added quite a few commonly requested functions to the dino economy.

Major: Changed to autoincrementing ID for dinos.

- Ability to mark multiple dinos as favorite or not.
- Ability to bulk-breed  ("orgy") non-favorite dinos.
- Ability to view someones favorite or trash dinos in isolation
- Ability to favorite dinos you don't own.
- New button added to favorite a viewed or new dino.
- Global constant 24 hour cooldown rather than personal.
- Colored embeds different for new vs. viewed dinos.

This required generalising the breeding code and changing where dinos were fetched by name.