### PR TITLE
Small dino embed fixes

### DIFF
--- a/src/commands/NFD.ts
+++ b/src/commands/NFD.ts
@@ -1382,6 +1382,7 @@ class NFD {
               const newHotnessScore = this.calculateHotnessScore(covetShunDifference)
 
               const editedEmbed = EmbedBuilder.from(message.embeds[0])
+                .setTitle(nfd.name)
                 .setFooter({
                   text:
                     `${nfd.name} is worth ${this.getNFDPrice(nfd).toFixed(2)} Dino Bucks!` +

--- a/src/commands/NFD.ts
+++ b/src/commands/NFD.ts
@@ -366,6 +366,18 @@ class NFD {
     const collage = await this.makeCollage(collection)
     const fauxFileName = `${interaction.id}.png`
 
+    let dinoType
+    switch (type) {
+      case 'FAVORITES':
+        dinoType = 'favorite '
+        break
+      case 'TRASH':
+        dinoType = 'trash '
+        break
+      default:
+        dinoType = ''
+    }
+
     const imageAttachment = new AttachmentBuilder(collage, { name: fauxFileName })
     const embed = new EmbedBuilder()
       .setColor(this.NFD_COLOR)
@@ -376,7 +388,9 @@ class NFD {
       .setTitle(ownerName + "'s collection")
       .setImage(`attachment://${fauxFileName}`)
       .setFooter({
-        text: `${ownerName} owns ${collection.length} dinos worth ${totalValue.toFixed(2)} Dino Bucks in total. 🦖🙌`,
+        text: `${ownerName} owns ${collection.length} ${dinoType}dinos worth ${totalValue.toFixed(
+          2
+        )} Dino Bucks in total. 🦖🙌`,
       })
       .setDescription(ostr)
 


### PR DESCRIPTION
1. After renaming and coveting/shunning a dino, the updated name of the dino is now also shown in the title of the embed, not only in the footer.
2. The footer of a `/dino collection` embed now displays the type of the collection it is (all/favorite/trash dinos).