### PR TITLE
Remove prefix ask command and format output

### DIFF
--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -1,14 +1,12 @@
-import { ApplicationCommandOptionType, CommandInteraction, InteractionResponse, escapeMarkdown } from 'discord.js'
 import {
-  Discord,
-  SimpleCommand,
-  SimpleCommandMessage,
-  SimpleCommandOption,
-  SimpleCommandOptionType,
-  Slash,
-  SlashChoice,
-  SlashOption,
-} from 'discordx'
+  ApplicationCommandOptionType,
+  CommandInteraction,
+  InteractionResponse,
+  blockQuote,
+  bold,
+  escapeMarkdown,
+} from 'discord.js'
+import { Discord, Slash, SlashChoice, SlashOption } from 'discordx'
 
 const COMMAND_NAME = 'ask'
 const COMMAND_DESC = 'Ask a question to Wolfram Alpha'
@@ -26,37 +24,6 @@ class Ask {
 
     if (this.apiToken == '') {
       throw new Error('WOLFRAM_APP_ID needs to be set')
-    }
-  }
-
-  @SimpleCommand({ name: COMMAND_NAME, description: COMMAND_DESC, argSplitter: '\n' })
-  async simple(
-    @SimpleCommandOption({ name: 'question', type: SimpleCommandOptionType.String })
-    question: string | undefined,
-    @SimpleCommandOption({ name: 'units of measurement', type: SimpleCommandOptionType.Boolean })
-    units: string | undefined,
-    command: SimpleCommandMessage
-  ) {
-    if (!question) {
-      return await command.message.reply({
-        content: 'Usage: >ask <question>\n<units?> (metric or imperial)',
-        allowedMentions: { repliedUser: false },
-      })
-    }
-
-    if (this.isOnCooldown()) {
-      return
-    }
-
-    try {
-      const answer = await this.fetchAnswer(question, units)
-      return command.message.reply({ content: answer, allowedMentions: { repliedUser: false } })
-    } catch (err) {
-      console.error(err)
-      return command.message.reply({
-        content: 'There was a problem communicating with Wolfram Alpha.',
-        allowedMentions: { repliedUser: false },
-      })
     }
   }
 
@@ -104,10 +71,7 @@ class Ask {
     url.searchParams.append('i', question)
     url.searchParams.append('units', units.toLowerCase())
 
-    console.log(url)
-
     const response = await fetch(url)
-
     if (response.ok) {
       return escapeMarkdown(await response.text())
     }

--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -54,7 +54,7 @@ class Ask {
 
     try {
       const answer = await this.fetchAnswer(question, units)
-      return interaction.reply(`[${bold(escapeMarkdown(question))}] ${blockQuote(answer)}`)
+      return interaction.reply(`### ${escapeMarkdown(question)}\n${blockQuote(answer)}`)
     } catch (err) {
       console.error(err)
       return interaction.reply('There was a problem communicating with Wolfram Alpha.')

--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -1,9 +1,8 @@
 import {
   ApplicationCommandOptionType,
   CommandInteraction,
+  EmbedBuilder,
   InteractionResponse,
-  blockQuote,
-  bold,
   escapeMarkdown,
 } from 'discord.js'
 import { Discord, Slash, SlashChoice, SlashOption } from 'discordx'
@@ -54,7 +53,13 @@ class Ask {
 
     try {
       const answer = await this.fetchAnswer(question, units)
-      return interaction.reply(`### ${escapeMarkdown(question)}\n${blockQuote(answer)}`)
+      const capitalizedAnswer = answer.charAt(0).toUpperCase() + answer.slice(1)
+      const embed = new EmbedBuilder()
+        .setColor('#FBAB00') // MasterMind's color
+        .setTitle(escapeMarkdown(question))
+        .setDescription(capitalizedAnswer)
+
+      return await interaction.reply({ embeds: [embed] })
     } catch (err) {
       console.error(err)
       return interaction.reply({ content: 'There was a problem communicating with Wolfram Alpha.', ephemeral: true })

--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -54,7 +54,7 @@ class Ask {
 
     try {
       const answer = await this.fetchAnswer(question, units)
-      return interaction.reply(`[${escapeMarkdown(question)}] ${answer}`)
+      return interaction.reply(`[${bold(escapeMarkdown(question))}] ${blockQuote(answer)}`)
     } catch (err) {
       console.error(err)
       return interaction.reply('There was a problem communicating with Wolfram Alpha.')

--- a/src/commands/ask.ts
+++ b/src/commands/ask.ts
@@ -57,7 +57,7 @@ class Ask {
       return interaction.reply(`### ${escapeMarkdown(question)}\n${blockQuote(answer)}`)
     } catch (err) {
       console.error(err)
-      return interaction.reply('There was a problem communicating with Wolfram Alpha.')
+      return interaction.reply({ content: 'There was a problem communicating with Wolfram Alpha.', ephemeral: true })
     }
   }
 


### PR DESCRIPTION
- Remove prefix version of the ask command.
- Formats the output of the reply into an embed
  
![Discord_9BVixUA3zc](https://github.com/Brexbot/TwiggyBot/assets/63453504/f41dad6c-12ac-4b17-9b36-5028f9cf41f4)

