### PR TITLE
Add ability to choose opponent for duel

### DIFF
--- a/src/commands/duel.ts
+++ b/src/commands/duel.ts
@@ -160,7 +160,7 @@ export class Duel {
       // Check if the acceptor has recently lost and can't duel right now. Print their timeout.
       const acceptorCooldownEnd = accepterStats.lastLoss.getTime() + DUEL_COOLDOWN
       if (acceptorCooldownEnd > Date.now()) {
-        return await collectionInteraction.followUp({
+        return collectionInteraction.followUp({
           content: `${accepter}, you have recently lost a duel. You can duel again <t:${Math.floor(acceptorCooldownEnd / 1000)}:R>.`,
           ephemeral: true,
           allowedMentions: { repliedUser: false },
@@ -179,7 +179,7 @@ export class Duel {
         // Disable the button
         const button = this.createButton(true)
         const row = new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(button)
-        return await collectionInteraction.editReply({
+        return collectionInteraction.editReply({
           components: [row],
         })
       }


### PR DESCRIPTION
Add the options to create duels which can be accepted by only one specific person (named duels).

Named duels share the same cooldown with the global ones the two kinds cannot be used at the same time but they do have a slightly shorter timeout for finding an opponent (3 vs 5 minutes).