### PR TITLE
Update duels

### DIFF
--- a/src/commands/duel.ts
+++ b/src/commands/duel.ts
@@ -83,6 +83,12 @@ class Duel {
       })
     }
 
+    const wagerMsg = wager ? '> ' + wager + '\n' : ''
+    let timeoutDuration = GLOBAL_DUEL_TIMEOUT_DURATION
+    let content = `${wagerMsg}${challenger} is looking for a duel, press the button to accept.`
+    let failedDuelContent = `${wagerMsg}${challenger} failed to find someone to duel.`
+
+    // Differenciate between a global duel and a named one
     if (wantedAccepter) {
       // Check wanted accepter cooldown before creating a duel
       // The duel would almost certantly time out if that were the case
@@ -98,6 +104,10 @@ class Duel {
           content: `${wantedAccepter} has recently lost a duel, you cannot challenge them right now. They can duel again <t:${Math.floor(wantedAccepterCooldownEnd / 1000)}:R>.`,
         })
       }
+
+      timeoutDuration = NAMED_DUEL_TIMEOUT_DURATION
+      content = `${wagerMsg}${challenger} is looking for a duel against ${wantedAccepter}, press the button to accept.`
+      failedDuelContent = `${wagerMsg}${wantedAccepter} failed accept ${challenger}'s duel.`
     }
 
     // Are we on global CD?
@@ -119,24 +129,16 @@ class Duel {
     }
 
     this.inProgress = true
-    const wagerMsg = wager ? '> ' + wager + '\n' : ''
 
     // Disable the duel after a timeout
-    const timeoutDuration = wantedAccepter ? NAMED_DUEL_TIMEOUT_DURATION : GLOBAL_DUEL_TIMEOUT_DURATION
     this.timeout = setTimeout(async () => {
       this.inProgress = false
       // Disable the button
       const button = this.createButton(true)
       const row = new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(button)
-      await interaction.editReply({
-        content: `${wagerMsg}${challenger} failed to find someone to duel.`,
-        components: [row],
-      })
+      await interaction.editReply({ content: failedDuelContent, components: [row] })
     }, timeoutDuration)
 
-    const content = wantedAccepter
-      ? `${wagerMsg}${challenger} is looking for a duel against ${wantedAccepter}, press the button to accept.`
-      : `${wagerMsg}${challenger} is looking for a duel, press the button to accept.`
     const row = new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(this.createButton(false))
     const response = await interaction.reply({ content, withResponse: true, components: [row] })
 

--- a/src/commands/duel.ts
+++ b/src/commands/duel.ts
@@ -64,19 +64,19 @@ class Duel {
       })
     }
 
-    const challengerStats = await this.getUserWithDuelStats(interaction.user.id)
-    if (!challengerStats) {
+    // Check if a duel is currently already going on.
+    if (this.inProgress) {
       return interaction.reply({
-        content: 'An unexpected error occurred.',
+        content: 'A duel is already in progress.',
         ephemeral: true,
         allowedMentions: { repliedUser: false },
       })
     }
 
-    // Check if a duel is currently already going on.
-    if (this.inProgress) {
+    const challengerStats = await this.getUserWithDuelStats(interaction.user.id)
+    if (!challengerStats) {
       return interaction.reply({
-        content: 'A duel is already in progress.',
+        content: 'An unexpected error occurred.',
         ephemeral: true,
         allowedMentions: { repliedUser: false },
       })

--- a/src/commands/duel.ts
+++ b/src/commands/duel.ts
@@ -25,8 +25,8 @@ import {
 } from '../utils/CommandUtils.js'
 import { shuffleArray } from '../utils/Helpers.js'
 
-export const DUEL_COOLDOWN = 10 * 60 * 1000 // Cooldown period after loss in milliseconds
-const GLOBAL_DUEL_TIMEOUT_DURATION = 5 * 60 * 1000
+export const DUEL_COOLDOWN = 10 * 10 * 1000 // Cooldown period after loss in milliseconds
+const GLOBAL_DUEL_TIMEOUT_DURATION = 5 * 10 * 1000
 const NAMED_DUEL_TIMEOUT_DURATION = 1 * 60 * 1000
 const DRAW_TIMEOUT_DURATION = 10 * 60 * 1000
 
@@ -56,7 +56,7 @@ class Duel {
       type: ApplicationCommandOptionType.User,
       description: 'The one person who can accept the duel',
     })
-    wantedAccepter: User | undefined,
+    wantedAccepter: GuildMember | undefined,
     interaction: CommandInteraction
   ) {
     // Get the challenger from the DB. Create them if they don't exist yet.
@@ -64,7 +64,8 @@ class Duel {
     if (challenger.id === wantedAccepter?.id) {
       return ephemeralReply(interaction, { content: 'You cannot duel yourself.' })
     }
-    if (wantedAccepter?.bot) {
+
+    if (wantedAccepter?.user.bot) {
       return ephemeralReply(interaction, { content: 'Stop trying to fight a bot, chat.' })
     }
 
@@ -222,7 +223,7 @@ class Duel {
 
         winnerText = `${challenger} has won!`
       } else if (accepterScore > challengerScore) {
-        await this.updateUserScore(challengerStats.duelStats[0] as Duels, 'loss')
+        await this.updateUserScore(challengerStats.duelStats[0], 'loss')
         await this.updateUserScore(accepterStats.duelStats[0], 'win')
 
         const [guild, member] = getGuildAndCallerFromCommand(interaction)
@@ -230,7 +231,7 @@ class Duel {
 
         winnerText = `${accepter} has won!`
       } else {
-        await this.updateUserScore(challengerStats.duelStats[0] as Duels, 'draw')
+        await this.updateUserScore(challengerStats.duelStats[0], 'draw')
         await this.updateUserScore(accepterStats.duelStats[0], 'draw')
 
         const challengerMember = getCallerFromCommand(interaction)

--- a/src/commands/duel.ts
+++ b/src/commands/duel.ts
@@ -150,7 +150,7 @@ class Duel {
     collector.on('collect', async (collectionInteraction: ButtonInteraction) => {
       await collectionInteraction.deferUpdate()
 
-      // Prevent accepting your own duels and ensure that the acceptor is valid.
+      // Prevent accepting your own duels and ensure that the accepter is valid.
       const accepter = collectionInteraction.user
       if (wantedAccepter && accepter.id !== wantedAccepter.id) {
         return ephemeralButtonFollowup(collectionInteraction, { content: "This duel wasn't meant for you, BEGONE!" })
@@ -161,11 +161,11 @@ class Duel {
         return
       }
 
-      // Check if the acceptor has recently lost and can't duel right now. Print their timeout.
-      const acceptorCooldownEnd = accepterStats.lastLoss.getTime() + DUEL_COOLDOWN
-      if (acceptorCooldownEnd > Date.now()) {
+      // Check if the accepter has recently lost and can't duel right now. Print their timeout.
+      const accepterCooldownEnd = accepterStats.lastLoss.getTime() + DUEL_COOLDOWN
+      if (accepterCooldownEnd > Date.now()) {
         return ephemeralButtonFollowup(collectionInteraction, {
-          content: `${accepter}, you have recently lost a duel. You can duel again <t:${Math.floor(acceptorCooldownEnd / 1000)}:R>.`,
+          content: `${accepter}, you have recently lost a duel. You can duel again <t:${Math.floor(accepterCooldownEnd / 1000)}:R>.`,
         })
       }
 

--- a/src/commands/duel.ts
+++ b/src/commands/duel.ts
@@ -51,12 +51,12 @@ class Duel {
       type: ApplicationCommandOptionType.User,
       description: 'The one person who can accept the duel',
     })
-    wanted_accepter: User | undefined,
+    wantedAccepter: User | undefined,
     interaction: CommandInteraction
   ) {
     // Get the challenger from the DB. Create them if they don't exist yet.
     const challenger = interaction.user
-    if (challenger.id === wanted_accepter?.id) {
+    if (challenger.id === wantedAccepter?.id) {
       return interaction.reply({
         content: 'You cannot duel yourself.',
         ephemeral: true,
@@ -116,7 +116,7 @@ class Duel {
     const wagerMsg = wager ? '> ' + wager + '\n' : ''
 
     // Disable the duel after a timeout
-    const timeoutDuration = wanted_accepter ? NAMED_DUEL_TIMEOUT_DURATION : GLOBAL_DUEL_TIMEOUT_DURATION
+    const timeoutDuration = wantedAccepter ? NAMED_DUEL_TIMEOUT_DURATION : GLOBAL_DUEL_TIMEOUT_DURATION
     this.timeout = setTimeout(async () => {
       this.inProgress = false
       // Disable the button
@@ -128,8 +128,8 @@ class Duel {
       })
     }, timeoutDuration)
 
-    const content = wanted_accepter
-      ? `${wagerMsg}${challenger} is looking for a duel against ${wanted_accepter}, press the button to accept.`
+    const content = wantedAccepter
+      ? `${wagerMsg}${challenger} is looking for a duel against ${wantedAccepter}, press the button to accept.`
       : `${wagerMsg}${challenger} is looking for a duel, press the button to accept.`
     const row = new ActionRowBuilder<MessageActionRowComponentBuilder>().addComponents(this.createButton(false))
     const response = await interaction.reply({ content, withResponse: true, components: [row] })
@@ -144,7 +144,7 @@ class Duel {
 
       // Prevent accepting your own duels and ensure that the acceptor is valid.
       const accepter = collectionInteraction.user
-      if (wanted_accepter && accepter.id !== wanted_accepter.id) {
+      if (wantedAccepter && accepter.id !== wantedAccepter.id) {
         return collectionInteraction.followUp({
           content: "This duel wasn't meant for you, BEGONE!",
           ephemeral: true,

--- a/src/commands/duel.ts
+++ b/src/commands/duel.ts
@@ -92,6 +92,27 @@ class Duel {
       })
     }
 
+    if (wantedAccepter) {
+      // Check wanted accepter cooldown before creating a duel
+      // The duel would almost certantly time out if that were the case
+      const wantedAccepterStats = await this.getUserWithDuelStats(wantedAccepter.id)
+      if (!wantedAccepterStats) {
+        return interaction.reply({
+          content: "An unexpected error occurred while fetching your opponents' stats.",
+          ephemeral: true,
+          allowedMentions: { repliedUser: false },
+        })
+      }
+      const wantedAccepterCooldownEnd = wantedAccepterStats.lastLoss.getTime() + DUEL_COOLDOWN
+      if (wantedAccepterCooldownEnd > Date.now()) {
+        return interaction.reply({
+          content: `${wantedAccepter} has recently lost a duel, you cannot challenge them right now. They can duel again <t:${Math.floor(wantedAccepterCooldownEnd / 1000)}:R>.`,
+          ephemeral: true,
+          allowedMentions: { repliedUser: false },
+        })
+      }
+    }
+
     // Are we on global CD?
     // todo MultiGuild: This shouldn't be hardcoded (#Mixu's id)
     const guildId = interaction.guildId

--- a/src/commands/duel.ts
+++ b/src/commands/duel.ts
@@ -59,6 +59,10 @@ class Duel {
     wantedAccepter: GuildMember | undefined,
     interaction: CommandInteraction
   ) {
+    if (wager && wager.length > 420) {
+      return ephemeralReply(interaction, { content: 'Stop.' })
+    }
+
     // Get the challenger from the DB. Create them if they don't exist yet.
     const challenger = interaction.user
     if (challenger.id === wantedAccepter?.id) {

--- a/src/commands/duel.ts
+++ b/src/commands/duel.ts
@@ -64,6 +64,9 @@ class Duel {
     if (challenger.id === wantedAccepter?.id) {
       return ephemeralReply(interaction, { content: 'You cannot duel yourself.' })
     }
+    if (wantedAccepter?.bot) {
+      return ephemeralReply(interaction, { content: 'Stop trying to fight a bot, chat.' })
+    }
 
     // Check if a duel is currently already going on.
     if (this.inProgress) {

--- a/src/commands/duel.ts
+++ b/src/commands/duel.ts
@@ -27,7 +27,7 @@ import { shuffleArray } from '../utils/Helpers.js'
 
 export const DUEL_COOLDOWN = 10 * 60 * 1000 // Cooldown period after loss in milliseconds
 const GLOBAL_DUEL_TIMEOUT_DURATION = 5 * 60 * 1000
-const NAMED_DUEL_TIMEOUT_DURATION = 3 * 60 * 1000
+const NAMED_DUEL_TIMEOUT_DURATION = 1 * 60 * 1000
 const DRAW_TIMEOUT_DURATION = 10 * 60 * 1000
 
 @Discord()

--- a/src/utils/CommandUtils.ts
+++ b/src/utils/CommandUtils.ts
@@ -1,4 +1,13 @@
-import { ButtonInteraction, CommandInteraction, Guild, GuildMember, User } from 'discord.js'
+import {
+  ButtonInteraction,
+  CommandInteraction,
+  Guild,
+  GuildMember,
+  InteractionReplyOptions,
+  InteractionResponse,
+  Message,
+  User,
+} from 'discord.js'
 import { SimpleCommandMessage } from 'discordx'
 
 export function getGuildFromCommand(
@@ -45,4 +54,26 @@ export function getNicknameFromUser(target: User | GuildMember, guild: Guild): s
     // Implies the user has left the server
     return target.username
   }
+}
+
+export function ephemeralReply(
+  interaction: CommandInteraction,
+  options: InteractionReplyOptions
+): Promise<InteractionResponse<boolean>> {
+  return interaction.reply({
+    ephemeral: true,
+    allowedMentions: { repliedUser: false },
+    ...options,
+  })
+}
+
+export function ephemeralButtonFollowup(
+  interaction: ButtonInteraction,
+  options: InteractionReplyOptions
+): Promise<Message<boolean>> {
+  return interaction.followUp({
+    ephemeral: true,
+    allowedMentions: { repliedUser: false },
+    ...options,
+  })
 }


### PR DESCRIPTION
- update the wanted_accepter to be camelCase (this is what rust does to your brain)
- check if the wantedAccepter is on cooldown before creating a duel, this decreases the likelihood of the duel staying there not accepted and having to time out because it's impossible to join
- reduce the need of having to specify { ephemeral: true, allowedMentions: { repliedUser: false } }, the helper function should be used in other commands moving forward.
- Don't allow chat to fight bots.